### PR TITLE
Add method for `POST v1/projects/:projectId/forecasts/:id/wells`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Mathematics',
     'Topic :: Software Development :: Libraries',
@@ -45,11 +48,16 @@ classifiers = [
 ]
 
 
-[project.optional-dependencies]
+# Optional dependencies specified in pyproject.toml should be only for end-user runtime installation behavior
+# and they are not intended for build/development time for the developer. instead this is the responsibility
+# of the build tool itself, or should be manually provided.
+# For dev dependencies required by developers working on the project we define: [dependency-groups]
+
+[dependency-groups]
 dev = [
-    'flake8>=6.1.0',
-    'flake8-pyproject>=1.2.3',
-    'mypy>=1.7.0',
+    "flake8>=5.0.4",
+    "flake8-pyproject>=1.2.3",
+    "mypy>=1.7.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "flake8>=5.0.4",
     "flake8-pyproject>=1.2.3",
     "mypy>=1.7.0",
+    "types-requests>=2.32.0.20241016",
 ]
 
 

--- a/src/combocurve_api_helper/__init__.py
+++ b/src/combocurve_api_helper/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.4'
+__version__ = '1.2.0'
 
 from .root import Root
 from .projects import Projects

--- a/src/combocurve_api_helper/base.py
+++ b/src/combocurve_api_helper/base.py
@@ -6,7 +6,7 @@ from more_itertools import chunked
 from typing import List, Dict, Optional, Union, Any, Iterable, Iterator, Mapping
 from typing_extensions import Self, TypeAlias
 
-import requests  # type: ignore
+import requests
 from requests import Response
 from combocurve_api_v1 import ServiceAccount, ComboCurveAuth  # type: ignore
 from combocurve_api_v1.pagination import get_next_page_url  # type: ignore

--- a/src/combocurve_api_helper/econ_runs.py
+++ b/src/combocurve_api_helper/econ_runs.py
@@ -1,4 +1,4 @@
-import requests  # type: ignore
+import requests
 import warnings
 
 from combocurve_api_v1.pagination import get_next_page_url  # type: ignore

--- a/src/combocurve_api_helper/forecasts.py
+++ b/src/combocurve_api_helper/forecasts.py
@@ -1,6 +1,8 @@
 import warnings
 from typing import List, Dict, Optional, Union, Any, Iterator, Mapping
 
+import requests
+
 from .base import APIBase, Item, ItemList
 
 
@@ -219,6 +221,29 @@ class Forecasts(APIBase):
         forecasts = self._post_items(url, data)
 
         return forecasts
+
+    def post_forecast_wells(
+        self,
+        project_id: str,
+        forecast_id: str,
+        well_ids: List[str],
+    ) -> ItemList:
+        """
+        Scope a list of well id's to a specific forecast, for a given project.
+
+        https://docs.api.combocurve.com/#8cd55b04-67a2-4534-bace-10504ac5ccd4
+        """
+        # NOTE: we can't use `self._post_items` since it expects the base data to be a list
+        # whereas this particular endpoint receives an object
+
+        headers = self.auth.get_auth_headers()
+        url = self.get_forecast_wells_url(project_id, forecast_id)
+        data = {"wellIds": well_ids}
+
+        response = requests.post(url, headers=headers, json=data)
+        response.raise_for_status()
+
+        return self._extract_json(response)
 
 
     def get_forecast_by_id(self, project_id: str, forecast_id: str) -> Item:

--- a/src/combocurve_api_helper/scenarios.py
+++ b/src/combocurve_api_helper/scenarios.py
@@ -1,4 +1,4 @@
-import requests  # type: ignore
+import requests
 import warnings
 
 from combocurve_api_v1.pagination import get_next_page_url  # type: ignore


### PR DESCRIPTION
This PR adds the `post_forecast_wells` method for `POST`-ing wells to a specific `forecast_id` for a given `project_id`.

Secondary changes include relaxing development dependencies to `"flake8>=5.0.4"` (to support Python 3.8) and adding `"types-requests>=2.32.0.20241016"` to developer dependencies to support type checking with `mypy` for the `requests` package.

[ComboCurve API docs](https://docs.api.combocurve.com/#8cd55b04-67a2-4534-bace-10504ac5ccd4)